### PR TITLE
Swap "off chain" for on-chain in fraud proofing section

### DIFF
--- a/_pages/overview.md
+++ b/_pages/overview.md
@@ -181,7 +181,8 @@ able to collect their funds as well.
 ![Dave distributes R](http://imgur.com/nTLWBbm.png)
 
 Now, everyone can clear out, because they have a guaranteed way to pull their
-deserved funds by broadcasting these HTLCs off chain. They would prefer not to
+deserved funds by broadcasting these HTLCs onto Bitcoin's network
+(i.e. on-chain).  They would prefer not to
 do that though, since broadcasting on-chain is more expensive, and instead
 settle each of these hops off chain. Alice knows that Bob can pull funds from
 her since he has `R`, so she tells Bob: "I'll pay you, regardless of `R`, and in


### PR DESCRIPTION
Could be totally wrong about this, but I think you meant "on-chain" where you wrote "off chain," since I think you're referring to broadcasting onto Bitcoin's network.