### PR TITLE
We need 100 block for Charlie's coins to appear in his wallet

### DIFF
--- a/tutorial/01-lncli.md
+++ b/tutorial/01-lncli.md
@@ -318,7 +318,7 @@ It's no fun if only Alice any money. Let's give some to Charlie as well:
 btcd --txindex --simnet --rpcuser=kek --rpcpass=kek --miningaddr=<CHARLIE_ADDRESS>
 
 # Generate more blocks
-btcctl --simnet --rpcuser=kek --rpcpass=kek generate 50
+btcctl --simnet --rpcuser=kek --rpcpass=kek generate 100
 
 # Check Charlie's balance
 charlie$ lncli-charlie walletbalance --witness_only=true


### PR DESCRIPTION
If we only generate 50 blocks for charlie, when it comes time for him to set up a channel with Bob, none of his coins will be valid yet, leading to errors about zero balance.