### PR TITLE
https for lightning.community gives nasty untrusted site warnings in …

### DIFF
--- a/tutorial/02-web-client.md
+++ b/tutorial/02-web-client.md
@@ -39,7 +39,7 @@ try this on your own - the web dashboard is intuitive enough that we don't need
 step by step instructions for it.
 
 Note: The LND wallet is coming soon! Sign up for our newsletter at the bottom
-of our [community page](https://lightning.community#mc-embedded-subscribe-form)
+of our [community page](http://lightning.community#mc-embedded-subscribe-form)
 
 ### Moving on to Step 3
 

--- a/tutorial/02-web-client.md
+++ b/tutorial/02-web-client.md
@@ -39,7 +39,7 @@ try this on your own - the web dashboard is intuitive enough that we don't need
 step by step instructions for it.
 
 Note: The LND wallet is coming soon! Sign up for our newsletter at the bottom
-of our [community page](http://lightning.community#mc-embedded-subscribe-form)
+of our [community page](//lightning.community#mc-embedded-subscribe-form)
 
 ### Moving on to Step 3
 


### PR DESCRIPTION
…firefox

This patch changes the mailing list link to http. I'm not sure who I should contact about getting proper https configured on lightning.community itself.