### PR TITLE
Nitpick: Change gopath env variable

### DIFF
--- a/tutorial/01-lncli.md
+++ b/tutorial/01-lncli.md
@@ -166,7 +166,7 @@ Keep in mind that for each additional terminal window you set, you will need to
 set `$GOPATH` and include `$GOPATH/bin` in your `PATH`. Consider creating a
 setup script that includes the following lines:
 ```bash
-export GOPATH=~/projects/lightning # if you exactly followed the install guide
+export GOPATH=~/gocode # if you exactly followed the install guide
 export PATH=$PATH:$GOPATH/bin
 ```
 and run it every time you start a new terminal window working on `lnd`.


### PR DESCRIPTION
In the comment beside the gopath env variable you refer to the installation docs:
https://github.com/lightninglabs/lightning-dev-site/blob/master/guides/installation.md

In those installation docs the export refers to `~/gocode` and not `~/projects/lightning` 

So we either fix this reference or the installation docs?