### PR TITLE
Change block generation to 6 to have a fully working channel

### DIFF
--- a/tutorial/01-lncli.md
+++ b/tutorial/01-lncli.md
@@ -251,6 +251,7 @@ To see all the commands available for `lncli`, simply type `lncli --help` or
 `lncli -h`.
 
 ### Setting up Bitcoin addresses
+
 Let's create a new Bitcoin address for Alice. This will be the address that
 stores Alice's on-chain balance.
 
@@ -318,8 +319,9 @@ Generate 400 blocks, so that Alice gets the reward. We need at least 100 blocks
 because coinbase funds can't be spent until after 100 confirmations, and we
 need about 300 to activate segwit.
 window with `$GOPATH` and `$PATH` set.
+
 ```bash
-alice$ btcctl --simnet --rpcuser=kek --rpcpass=kek generate 400
+btcctl --simnet --rpcuser=kek --rpcpass=kek generate 400
 ```
 
 Check that segwit is active:
@@ -329,11 +331,13 @@ btcctl --simnet --rpcuser=kek --rpcpass=kek getblockchaininfo | grep -A 1 segwit
 
 Check Alice's wallet balance. `--witness_only=true` specifies that we only want
 to consider witness outputs when calculating the wallet balance.
+
 ```bash
 alice$ lncli-alice walletbalance --witness_only=true
 ```
 
 It's no fun if only Alice any money. Let's give some to Charlie as well:
+
 ```bash
 # Quit btcd
 btcd --txindex --simnet --rpcuser=kek --rpcpass=kek --miningaddr=<CHARLIE_ADDRESS>
@@ -417,8 +421,19 @@ bob$ lncli-bob listpeers
 ```
 
 Finish up the P2P network by connecting Bob to Charlie:
+
 ```bash
 charlie$ lncli-charlie connect <BOB_PUBKEY>@localhost:10012
+```
+
+and testing their connections:
+
+```bash
+# Check that Charlie has added Bob as a peer:
+charlie$ lncli-charlie listpeers
+
+# Check that Bob has added Charlie as a peer
+bob$ lncli-bob listpeers
 ```
 
 ### Setting up Lightning Network
@@ -427,19 +442,23 @@ Before we can send payment, we will need to set up payment channels from Alice
 to Bob, and Bob to Charlie.
 
 First, let's open the Alice<-->Bob channel.
+
 ```bash
 alice$ lncli-alice openchannel --node_key=<BOB_PUBKEY> --local_amt=1000000
 ```
-- `--local_amt` specifies the amount of money that Alice will commit to the
+
+- `--local_amt` specifies the amount of Satoshi that Alice will commit to the
   channel.  To see the full list of options, you can try `lncli openchannel
   --help`.
 
-We now need to mine three blocks so that the channel is considered valid:
+We now need to mine six blocks so that the channel is considered valid:
+
 ```bash
-btcctl --simnet --rpcuser=kek --rpcpass=kek generate 3
+btcctl --simnet --rpcuser=kek --rpcpass=kek generate 6
 ```
 
 Check that Alice<-->Bob channel was created:
+
 ```bash
 alice$ lncli-alice listchannels
 {
@@ -470,8 +489,9 @@ Finally, to the exciting part - sending payments! Let's send a payment from
 Alice to Bob.
 
 First, Bob will need to generate an invoice:
+
 ```bash
-bob$ lncli-bob addinvoice --value=10000
+bob$ lncli-bob addinvoice --value=100000
 {
         "r_hash": "<a_random_rhash_value>",
         "pay_req": "<encoded_invoice>",
@@ -479,18 +499,19 @@ bob$ lncli-bob addinvoice --value=10000
 ```
 
 Send the payment from Alice to Bob:
+
 ```bash
 alice$ lncli-alice sendpayment --pay_req=<encoded_invoice>
 {
 	"payment_preimage": "baf6929fc95b3824fb774a4b75f6c8a1ad3aaef04efbf26cc064904729a21e28",
 	"payment_route": {
 		"total_time_lock": 1,
-		"total_amt": 10000,
+		"total_amt": 100000,
 		"hops": [
 			{
 				"chan_id": 495879744192512,
 				"chan_capacity": 1000000,
-				"amt_to_forward": 10000
+				"amt_to_forward": 100000
 			}
 		]
 	}
@@ -507,17 +528,19 @@ bob$ lncli-bob listchannels
 
 Now that we know how to send single-hop payments, sending multi hop payments is
 not that much more difficult. Let's set up a channel from Bob<-->Charlie:
+
 ```bash
 charlie$ lncli-charlie openchannel --node_key=<BOB_PUBKEY> --local_amt=800000 --push_amt=200000
 
 # Mine the channel funding tx
-btcctl --simnet --rpcuser=kek --rpcpass=kek generate 3
+btcctl --simnet --rpcuser=kek --rpcpass=kek generate 6
 ```
 
 Note that this time, we supplied the `--push_amt` argument, which specifies the
 amount of money we want to other party to have at the first channel state.
 
 Let's make a payment from Alice to Charlie by routing through Bob:
+
 ```bash
 charlie$ lncli-charlie addinvoice --value=10000
 alice$ lncli-alice sendpayment --pay_req=<encoded_invoice>
@@ -556,6 +579,7 @@ alice$ lncli-alice listchannels
 The Channel point consists of two numbers separated by a colon, which uniquely
 identifies the channel. The first number is `funding_txid` and the second
 number is `output_index`.
+
 ```bash
 # Close the Alice<-->Bob channel from Alice's side.
 alice$ lncli-alice closechannel --funding_txid=<funding_txid> --output_index=<output_index>
@@ -567,7 +591,7 @@ btcctl --simnet --rpcuser=kek --rpcpass=kek generate 1
 # channel. Recall that Bob previously had no on-chain Bitcoin:
 alice$ lncli-bob walletbalance
 {
-    "balance": "20001"
+    "balance": "110001"
 }
 ```
 

--- a/tutorial/01-lncli.md
+++ b/tutorial/01-lncli.md
@@ -584,8 +584,8 @@ number is `output_index`.
 # Close the Alice<-->Bob channel from Alice's side.
 alice$ lncli-alice closechannel --funding_txid=<funding_txid> --output_index=<output_index>
 
-# Mine a block including the channel close transaction to close the channel:
-btcctl --simnet --rpcuser=kek --rpcpass=kek generate 1
+# Mine 6 blocks including the channel close transaction to close the channel:
+btcctl --simnet --rpcuser=kek --rpcpass=kek generate 6
 
 # Check that Bob's on-chain balance was credited by his settled amount in the
 # channel. Recall that Bob previously had no on-chain Bitcoin:


### PR DESCRIPTION
Hi there, I made few modification to allow Bob to be an hop in the route between Alice and Charlie for the multi-hope-payment scenario. I also added few carriage return before the `bash` MD markers and increment the number of block to be generated from 3 to 6 which seems to be required for the funding tx. HIH