### PR TITLE
Update command line options in install guide and lncli tutorial

### DIFF
--- a/guides/installation.md
+++ b/guides/installation.md
@@ -177,7 +177,7 @@ Otherwise, replace `--bitcoin.testnet` with `--bitcoin.simnet`. If you are
 installing `lnd` in preparation for the
 [tutorial](http://dev.lightning.community/tutorial), you may skip this step.
 ```
-lnd --bitcoin.active --bitcoin.testnet --debuglevel=debug --bitcoin.rpcuser=kek --bitcoin.rpcpass=kek --externalip=X.X.X.X
+lnd --bitcoin.active --bitcoin.testnet --debuglevel=debug --bitcoin.node=btcd --btcd.rpcuser=kek --btcd.rpcpass=kek --externalip=X.X.X.X
 ```
 
 #### Disabling Wallet Encryption

--- a/tutorial/01-lncli.md
+++ b/tutorial/01-lncli.md
@@ -113,15 +113,15 @@ The directory structure should now look like this:
 $ tree $GOPATH -L 2
 
 ├── bin
-│   └── ...
+│   └── ...
 ├── dev
-│   ├── alice
-│   ├── bob
-│   └── charlie
+│   ├── alice
+│   ├── bob
+│   └── charlie
 ├── pkg
-│   └── ...
+│   └── ...
 ├── rpc
-│   └── ...
+│   └── ...
 └── src
     └── ...
 ```
@@ -129,7 +129,7 @@ $ tree $GOPATH -L 2
 Start up the Alice node from within the `alice` directory:
 ```bash
 cd $GOPATH/dev/alice
-alice$ lnd --rpcport=10001 --peerport=10011 --restport=8001 --datadir=test_data --logdir=test_log --debuglevel=info --no-macaroons --bitcoin.rpcuser=kek --bitcoin.rpcpass=kek --bitcoin.simnet --bitcoin.active
+alice$ lnd --rpcport=10001 --peerport=10011 --restport=8001 --datadir=test_data --logdir=test_log --debuglevel=info --no-macaroons --bitcoin.simnet --bitcoin.active --bitcoin.node=btcd --btcd.rpcuser=kek --btcd.rpcpass=kek
 ```
 The Alice node should now be running and displaying output.
 
@@ -149,11 +149,14 @@ Breaking down the components:
   * `--debuglevel`: The logging level for all subsystems. Can be set to
     `trace`, `debug`, `info`, `warn`, `error`, `critical`.
   * `--no-macaroons`: Disable macaroon authentication for tutorial purposes.
-  * `--bitcoin.rpcuser` and `--bitcoin.rpcpass`: The username and password for
-    the `btcd` instance
   * `--bitcoin.simnet`: Specifies whether to use `simnet` or `testnet`
   * `--bitcoin.active`: Specifies that bitcoin is active. Can also include
-    `--litecoin.active` to activate Litecoin
+    `--litecoin.active` to activate Litecoin.
+  * `--bitcoin.node=btcd`: Use the `btcd` full node to interface with the blockchain.
+    Note that when using Litecoin, the option is `--litecoin.node=btcd`.
+  * `--btcd.rpcuser` and `--btcd.rpcpass`: The username and password for
+    the `btcd` instance. Note that when using Litecoin, the options are `--ltcd.rpcuser`
+    and `--ltcd.rpcpass`.
 
 ### Running Bob and Charlie
 
@@ -175,11 +178,11 @@ Run Bob and Charlie:
 ```bash
 # In a new terminal window
 cd $GOPATH/dev/bob
-bob$ lnd --rpcport=10002 --peerport=10012 --restport=8002 --datadir=test_data --logdir=test_log --debuglevel=info --no-macaroons --bitcoin.rpcuser=kek --bitcoin.rpcpass=kek --bitcoin.simnet --bitcoin.active
+bob$ lnd --rpcport=10002 --peerport=10012 --restport=8002 --datadir=test_data --logdir=test_log --debuglevel=info --no-macaroons --bitcoin.simnet --bitcoin.active --bitcoin.node=btcd --btcd.rpcuser=kek --btcd.rpcpass=kek
 
 # In another terminal window
 cd $GOPATH/dev/charlie
-charlie$ lnd --rpcport=10003 --peerport=10013 --restport=8003 --datadir=test_data --logdir=test_log --debuglevel=info --no-macaroons --bitcoin.rpcuser=kek --bitcoin.rpcpass=kek --bitcoin.simnet --bitcoin.active
+charlie$ lnd --rpcport=10003 --peerport=10013 --restport=8003 --datadir=test_data --logdir=test_log --debuglevel=info --no-macaroons --bitcoin.simnet --bitcoin.active --bitcoin.node=btcd --btcd.rpcuser=kek --btcd.rpcpass=kek
 ```
 
 ### Configuring lnd.conf
@@ -206,8 +209,11 @@ no-macaroons=true
 [Bitcoin]
 bitcoin.simnet=1
 bitcoin.active=1
-bitcoin.rpcuser=kek
-bitcoin.rpcpass=kek
+bitcoin.node=btcd
+
+[Btcd]
+btcd.rpcuser=kek
+btcd.rpcpass=kek
 ```
 
 Now, when we start nodes, we only have to type


### PR DESCRIPTION
Since lnd has been updated with PR 447, a new convention is used to specify the configuration of the backing node (btcd, bitcoind, or neutrino). This PR updates the configurations for starting lnd
with a btcd backing node to fit the new configuration option convention.