### PR TITLE
Adding on 'error' example for subscribeInvoices

### DIFF
--- a/guides/javascript-grpc.md
+++ b/guides/javascript-grpc.md
@@ -89,6 +89,10 @@ call.on('data', function(invoice) {
 .on('status', function(status) {
   // Process status
   console.log("Current status" + status);
+})
+.on('error', function(err) {
+  // Lnd terminated unexpectedly
+  console.error(err);
 });
 ```
 


### PR DESCRIPTION
After using the examples in this guide, I realized that when LND terminated unexpectedly it resulted in an unhandled error that killed my application. I think adding this example of handling the `error` event from `subscribeInvoices` would be helpful and make this guide more complete.