### PR TITLE
Fix unknown flag `bitcoin.rpcuser' error

### DIFF
--- a/tutorial/01-lncli.md
+++ b/tutorial/01-lncli.md
@@ -129,7 +129,7 @@ $ tree $GOPATH -L 2
 Start up the Alice node from within the `alice` directory:
 ```bash
 cd $GOPATH/dev/alice
-alice$ lnd --rpcport=10001 --peerport=10011 --restport=8001 --datadir=test_data --logdir=test_log --debuglevel=info --no-macaroons --bitcoin.rpcuser=kek --bitcoin.rpcpass=kek --bitcoin.simnet --bitcoin.active
+alice$ lnd --rpcport=10001 --peerport=10011 --restport=8001 --datadir=test_data --logdir=test_log --debuglevel=info --no-macaroons --btcd.rpcuser=kek --btcd.rpcpass=kek --bitcoin.simnet --bitcoin.active
 ```
 The Alice node should now be running and displaying output.
 
@@ -149,7 +149,7 @@ Breaking down the components:
   * `--debuglevel`: The logging level for all subsystems. Can be set to
     `trace`, `debug`, `info`, `warn`, `error`, `critical`.
   * `--no-macaroons`: Disable macaroon authentication for tutorial purposes.
-  * `--bitcoin.rpcuser` and `--bitcoin.rpcpass`: The username and password for
+  * `--btcd.rpcuser` and `--btcd.rpcpass`: The username and password for
     the `btcd` instance
   * `--bitcoin.simnet`: Specifies whether to use `simnet` or `testnet`
   * `--bitcoin.active`: Specifies that bitcoin is active. Can also include
@@ -175,11 +175,11 @@ Run Bob and Charlie:
 ```bash
 # In a new terminal window
 cd $GOPATH/dev/bob
-bob$ lnd --rpcport=10002 --peerport=10012 --restport=8002 --datadir=test_data --logdir=test_log --debuglevel=info --no-macaroons --bitcoin.rpcuser=kek --bitcoin.rpcpass=kek --bitcoin.simnet --bitcoin.active
+bob$ lnd --rpcport=10002 --peerport=10012 --restport=8002 --datadir=test_data --logdir=test_log --debuglevel=info --no-macaroons --btcd.rpcuser=kek --btcd.rpcpass=kek --bitcoin.simnet --bitcoin.active
 
 # In another terminal window
 cd $GOPATH/dev/charlie
-charlie$ lnd --rpcport=10003 --peerport=10013 --restport=8003 --datadir=test_data --logdir=test_log --debuglevel=info --no-macaroons --bitcoin.rpcuser=kek --bitcoin.rpcpass=kek --bitcoin.simnet --bitcoin.active
+charlie$ lnd --rpcport=10003 --peerport=10013 --restport=8003 --datadir=test_data --logdir=test_log --debuglevel=info --no-macaroons --btcd.rpcuser=kek --btcd.rpcpass=kek --bitcoin.simnet --bitcoin.active
 ```
 
 ### Configuring lnd.conf
@@ -206,8 +206,8 @@ no-macaroons=true
 [Bitcoin]
 bitcoin.simnet=1
 bitcoin.active=1
-bitcoin.rpcuser=kek
-bitcoin.rpcpass=kek
+btcd.rpcuser=kek
+btcd.rpcpass=kek
 ```
 
 Now, when we start nodes, we only have to type


### PR DESCRIPTION
When running the command with the --bitcoin flag, it throws the error:

`unknown flag 'bitcoin.rpcuser'`

It seems that with `lnd`, you have to specify the actual bitcoin daemon that you're connecting to, so either `btcd` or `bitcoind`. Since the tutorial assumes you're using `btcd`, the tutorial should use that flag instead.