### PR TITLE
Changing addinvoice --value to --amt in guides

### DIFF
--- a/guides/docker.md
+++ b/guides/docker.md
@@ -192,7 +192,7 @@ alice$ lncli listchannels
 Send the payment form `Alice` to `Bob`.
 ```bash
 # Add invoice on "Bob" side:
-bob$ lncli addinvoice --value=10000
+bob$ lncli addinvoice --amt=10000
 {
         "r_hash": "<your_random_rhash_here>", 
         "pay_req": "<encoded_invoice>", 

--- a/guides/javascript-grpc.md
+++ b/guides/javascript-grpc.md
@@ -95,7 +95,7 @@ call.on('data', function(invoice) {
 Now, create an invoice for your node at `localhost:10009`and send a payment to
 it from another node.
 ```bash
-$ lncli addinvoice --value=100
+$ lncli addinvoice --amt=100
 {
 	"r_hash": <RHASH>,
 	"pay_req": <PAYMENT_REQUEST>

--- a/guides/python-grpc.md
+++ b/guides/python-grpc.md
@@ -89,7 +89,7 @@ for invoice in stub.SubscribeInvoices(request);
 Now, create an invoice for your node at `localhost:10009`and send a payment to
 it from another node.
 ```bash
-$ lncli addinvoice --value=100
+$ lncli addinvoice --amt=100
 {
 	"r_hash": <R_HASH>,
 	"pay_req": <PAY_REQ>


### PR DESCRIPTION
This applies the same fix as in #27 to fix the addinvoice calls which won't work with recent lnd commits. I figure it's possible to make these commands without the `--amt` flag at all but I'm leaving it in for consistency.