### PR TITLE
remove linebreak from inside oneline code block

### DIFF
--- a/_pages/overview.md
+++ b/_pages/overview.md
@@ -272,8 +272,8 @@ There are several ways to drive `lnd`.
 
 - `lncli` is the `lnd` command line tool. All commands are executed
   instantaneously. A full list of commands can be viewed with `lncli --help`.
-  To see a breakdown of the parameters for a particular command, run `lncli
-  <command> --help`
+  To see a breakdown of the parameters for a particular command, run
+  `lncli <command> --help`
 - gRPC is the preferred programmatic way interact with `lnd`. It includes simple
   methods that return a response immediately, as well as response-streaming and
   bidrectional streaming methods. Check out the guides for working with gRPC for


### PR DESCRIPTION
Super small cosmetic change. This one-line codeblock looked OK when github was rendering the markdown but not when Jekyll did it. 

Before:

<img width="784" alt="screen shot 2018-03-01 at 5 51 31 pm" src="https://user-images.githubusercontent.com/1275828/36874654-b96586b0-1d7a-11e8-9696-467e826c1d08.png">

After:

<img width="664" alt="screen shot 2018-03-01 at 5 50 44 pm" src="https://user-images.githubusercontent.com/1275828/36874664-c176dab6-1d7a-11e8-8bed-6148908f3420.png">
