### PR TITLE
update value to amt for all instances of addinvoice

### DIFF
--- a/_pages/overview.md
+++ b/_pages/overview.md
@@ -379,7 +379,7 @@ Let's now see what an ideal payment flow looks like.
    created for this good and it expired, or a sufficient amount of time has
    elapsed, a fresh invoice should be generated.
    ```shell
-   lncli addinvoice --value=6969 --memo="A coffee for Roger"
+   lncli addinvoice --amt=6969 --memo="A coffee for Roger"
    ```
    <img src="http://i.imgur.com/1xYB9Yq.png" alt="Lightning Wallet Generate Payment Request" style="max-width: 60%;"/>
 2. **Check invoice:** The payer decodes the invoice to see the destination,

--- a/guides/docker.md
+++ b/guides/docker.md
@@ -192,7 +192,7 @@ alice$ lncli listchannels
 Send the payment form `Alice` to `Bob`.
 ```bash
 # Add invoice on "Bob" side:
-bob$ lncli addinvoice --value=10000
+bob$ lncli addinvoice --amt=10000
 {
         "r_hash": "<your_random_rhash_here>", 
         "pay_req": "<encoded_invoice>", 

--- a/guides/javascript-grpc.md
+++ b/guides/javascript-grpc.md
@@ -95,7 +95,7 @@ call.on('data', function(invoice) {
 Now, create an invoice for your node at `localhost:10009`and send a payment to
 it from another node.
 ```bash
-$ lncli addinvoice --value=100
+$ lncli addinvoice --amt=100
 {
 	"r_hash": <RHASH>,
 	"pay_req": <PAYMENT_REQUEST>

--- a/guides/python-grpc.md
+++ b/guides/python-grpc.md
@@ -89,7 +89,7 @@ for invoice in stub.SubscribeInvoices(request);
 Now, create an invoice for your node at `localhost:10009`and send a payment to
 it from another node.
 ```bash
-$ lncli addinvoice --value=100
+$ lncli addinvoice --amt=100
 {
 	"r_hash": <R_HASH>,
 	"pay_req": <PAY_REQ>

--- a/tutorial/01-lncli.md
+++ b/tutorial/01-lncli.md
@@ -477,7 +477,7 @@ Alice to Bob.
 
 First, Bob will need to generate an invoice:
 ```bash
-bob$ lncli-bob addinvoice --value=10000
+bob$ lncli-bob addinvoice --amt=10000
 {
         "r_hash": "<a_random_rhash_value>",
         "pay_req": "<encoded_invoice>",
@@ -525,7 +525,7 @@ amount of money we want to other party to have at the first channel state.
 
 Let's make a payment from Alice to Charlie by routing through Bob:
 ```bash
-charlie$ lncli-charlie addinvoice --value=10000
+charlie$ lncli-charlie addinvoice --amt=10000
 alice$ lncli-alice sendpayment --pay_req=<encoded_invoice>
 
 # Check that Charlie's channel was credited with the payment amount (e.g. that

--- a/tutorial/04-webapp-integration.md
+++ b/tutorial/04-webapp-integration.md
@@ -308,7 +308,7 @@ def generate_invoice(self, user, article):
     channel = grpc.insecure_channel(settings.LND_RPCHOST)
     stub = lnrpc.LightningStub(channel)
 
-    add_invoice_resp = stub.AddInvoice(ln.Invoice(value=settings.MIN_VIEW_AMOUNT, memo="User '{}' | ArticleId {}".format(user.username, article.id)))
+    add_invoice_resp = stub.AddInvoice(ln.Invoice(amt=settings.MIN_VIEW_AMOUNT, memo="User '{}' | ArticleId {}".format(user.username, article.id)))
     r_hash_base64 = codecs.encode(add_invoice_resp.r_hash, 'base64')
     self.r_hash = r_hash_base64.decode('utf-8')
     self.payment_request = add_invoice_resp.payment_request


### PR DESCRIPTION
this commit (https://github.com/lightningnetwork/lnd/commit/ffbcf7db4f09cb932123029d201a9feef7894d7d) a couple months ago updated the field under `addinvoice` from `value` to `amt`.

This PR simply updates this site to reflect the API change. 