### PR TITLE
update clean branch name in webapp integration from start to starter

### DIFF
--- a/tutorial/04-webapp-integration.md
+++ b/tutorial/04-webapp-integration.md
@@ -13,7 +13,7 @@ It's time to recreate the micropayments ourselves. Get the starter code:
 ```bash
 # Clear any local changes first and checkout the start tag
 git checkout -- .
-git checkout start
+git checkout starter
 ```
 
 The starter code has stripped out all micropayments code, and we just also just


### PR DESCRIPTION
This is supposed to be `starter` not `start`. 
There are currently two open branches in the project, `master` and `starter`: https://github.com/lightninglabs/lightning-coindesk/branches