### PR TITLE
Add SSL cipher suites to javascript guide

### DIFF
--- a/guides/javascript-grpc.md
+++ b/guides/javascript-grpc.md
@@ -37,6 +37,8 @@ Every time you work with Javascript gRPC, you will have to import `grpc`, load
 var grpc = require('grpc');
 var fs = require("fs");
 
+process.env.GRPC_SSL_CIPHER_SUITES = "HIGH+ECDSA";
+
 //  Lnd cert is at ~/.lnd/tls.cert on Linux and
 //  ~/Library/Application Support/Lnd/tls.cert on Mac
 var lndCert = fs.readFileSync("~/.lnd/tls.cert");


### PR DESCRIPTION
It seems that recent versions of lnd requires cipher suites to be specified in the environment variables for the TLS handshake to work. Omitting this results in an error of `Handshake failed with fatal error SSL_ERROR_SSL: error:14094410:SSL routines:ssl3_read_bytes:sslv3 alert handshake failure.`