### PR TITLE
Minor corrections to the tutorials

### DIFF
--- a/tutorial/01-lncli.md
+++ b/tutorial/01-lncli.md
@@ -542,7 +542,7 @@ btcctl --simnet --rpcuser=kek --rpcpass=kek generate 6
 ```
 
 Note that this time, we supplied the `--push_amt` argument, which specifies the
-amount of money we want to other party to have at the first channel state.
+amount of money we want the other party to have at the first channel state.
 
 Let's make a payment from Alice to Charlie by routing through Bob:
 ```bash

--- a/tutorial/02-web-client.md
+++ b/tutorial/02-web-client.md
@@ -13,11 +13,8 @@ creator himself. Before beginning this step make sure you have `node` and `npm`
 
 ```bash
 # Clone the repo and move into it:
-cd $GOCODE/src/github.com
-mkdir mably
-cd mably
-git clone https://github.com/mably/lncli-web
-cd lncli-web
+git clone https://github.com/mably/lncli-web $GOPATH/src/github.com/mably/lncli-web
+cd $GOPATH/src/github.com/mably/lncli-web
 
 # Install dependencies
 npm install
@@ -34,10 +31,10 @@ openssl ecparam -genkey -name prime256v1 -out tls.key
 openssl req -new -sha256 -key tls.key -out csr.csr -subj '/CN=localhost/O=lnd'
 openssl req -x509 -sha256 -days 36500 -key tls.key -in csr.csr -out tls.cert
 rm csr.csr
-cp tls.cert $GOCODE/src/github.com/mably/lncli-web/lnd.cert
+cp tls.cert $GOPATH/src/github.com/mably/lncli-web/lnd.cert
 
 # Start the server to point to our Alice node:
-cd $GOCODE/src/github.com/mably/lncli-web
+cd $GOPATH/src/github.com/mably/lncli-web
 node server --lndhost=localhost:10001
 
 # Check out the available command line arguments

--- a/tutorial/03-rpc-client.md
+++ b/tutorial/03-rpc-client.md
@@ -61,7 +61,7 @@ an email address and password, we created an authentication scheme based on the
 user's `lnd` identity pubkey and logging in by signing an arbitrary message. In
 particular, we are signing the CSRF token sent along with the login POST
 request. This scheme is secure against replay attacks because Django generates
-a unique CSRF token for every login attempt, and never uses CSRF tokens.
+a unique CSRF token for every login attempt, and never reuses CSRF tokens.
 
 Let's create a new account for Alice by logging in and supplying a username.
 Copy down the generated message (in the screenshot, it is `VcccAuMC...`)
@@ -125,12 +125,12 @@ python manage.py shell
 ```python
 # Import rpc files and grpc
 In [1]: from coindesk import rpc_pb2 as ln, rpc_pb2_grpc as lnrpc
-In [2]: import grpc
+In [2]: import grpc, os
 
 # Establish a secure connection with our RPC server. We will first have to
 # gather our cert. Lnd cert is at ~/.lnd/tls.cert on Linux and
 # ~/Library/Application Support/Lnd/tls.cert on Mac
-In [3]: cert = open('~/.lnd/tls.cert').read()
+In [3]: cert = open(os.path.expanduser('~/.lnd/tls.cert')).read()
 In [4]: creds = grpc.ssl_channel_credentials(cert)
 In [5]: channel = grpc.secure_channel('localhost:10009', creds)
 # Create a new 'stub' object that will allow us to interact with our "Bob" lnd node.


### PR DESCRIPTION
 - A couple of typo corrections
 - Change the web client tutorial to use the git checkout pattern used in the first tutorial (also for brevity).
 - python's `open` does not resolve tilde ('~') by default. Call `os.path.expanduser` before using `open`.