### PR TITLE
add reference to bitcoind documentation for running lnd tests

### DIFF
--- a/guides/installation.md
+++ b/guides/installation.md
@@ -75,6 +75,10 @@ make && make install
 ```
 
 **Tests**
+Running tests does require `bitcoind` to be installed. Please see the [Running
+lnd using bitcoind or litecoind
+backend](#running-lnd-using-the-bitcoind-or-litecoind-backend) section of this
+documentation for instructions.
 
 To check that `lnd` was installed properly run the following command:
 ```


### PR DESCRIPTION
Fixes #44

When running `make check`, I had failures due to `bitcoind` not being installed. The documentation for install `bitcoind` is later in the documentation. So I added a reference to that point in the documentation so people A) know that its needed to run tests, and B) how to install it.