### PR TITLE
Update lncli flags

### DIFF
--- a/guides/docker.md
+++ b/guides/docker.md
@@ -74,7 +74,8 @@ $ docker-compose run -d --name alice lnd_btc
 $ docker exec -i -t alice bash
 
 # Generate a new backward compatible nested p2sh address for Alice:
-alice$ lncli newaddress np2wkh 
+# lncli requires the network to be specified if not mainnet.
+alice$ lncli --network=simnet newaddress np2wkh
 
 # Recreate "btcd" node and set Alice's address as mining address:
 $ MINING_ADDRESS=<alice_address> docker-compose up -d btcd
@@ -89,7 +90,7 @@ $ docker-compose run btcctl getblockchaininfo | grep -A 1 segwit
 
 Check `Alice` balance:
 ```
-alice$ lncli walletbalance
+alice$ lncli --network=simnet walletbalance
 ```
 
 Connect `Bob` node to `Alice` node.
@@ -100,7 +101,7 @@ $ docker-compose run -d --name bob lnd_btc
 $ docker exec -i -t bob bash
 
 # Get the identity pubkey of "Bob" node:
-bob$ lncli getinfo
+bob$ lncli --network=simnet getinfo
 
 {
     ----->"identity_pubkey": "0343bc80b914aebf8e50eb0b8e445fc79b9e6e8e5e018fa8c5f85c7d429c117b38",
@@ -121,10 +122,10 @@ bob$ lncli getinfo
 $ docker inspect bob | grep IPAddress
 
 # Connect "Alice" to the "Bob" node:
-alice$ lncli connect <bob_pubkey>@<bob_host>
+alice$ lncli --network=simnet connect <bob_pubkey>@<bob_host>
 
 # Check list of peers on "Alice" side:
-alice$ lncli listpeers
+alice$ lncli --network=simnet listpeers
 {
     "peers": [
         {
@@ -141,7 +142,7 @@ alice$ lncli listpeers
 }
 
 # Check list of peers on "Bob" side:
-bob$ lncli listpeers
+bob$ lncli --network=simnet listpeers
 {
     "peers": [
         {
@@ -161,13 +162,13 @@ bob$ lncli listpeers
 Create the `Alice<->Bob` channel.
 ```bash
 # Open the channel with "Bob":
-alice$ lncli openchannel --node_key=<bob_identity_pubkey> --local_amt=1000000
+alice$ lncli --network=simnet openchannel --node_key=<bob_identity_pubkey> --local_amt=1000000
 
 # Include funding transaction in block thereby opening the channel:
 $ docker-compose run btcctl generate 3
 
 # Check that channel with "Bob" was opened:
-alice$ lncli listchannels
+alice$ lncli --network=simnet listchannels
 {
     "channels": [
         {
@@ -196,20 +197,20 @@ alice$ lncli listchannels
 Send the payment from `Alice` to `Bob`.
 ```bash
 # Add invoice on "Bob" side:
-bob$ lncli addinvoice --amt=10000
+bob$ lncli --network=simnet addinvoice --amt=10000
 {
         "r_hash": "<your_random_rhash_here>", 
         "pay_req": "<encoded_invoice>", 
 }
 
 # Send payment from "Alice" to "Bob":
-alice$ lncli sendpayment --pay_req=<encoded_invoice>
+alice$ lncli --network=simnet sendpayment --pay_req=<encoded_invoice>
 
 # Check "Alice"'s channel balance
-alice$ lncli channelbalance
+alice$ lncli --network=simnet channelbalance
 
 # Check "Bob"'s channel balance
-bob$ lncli channelbalance
+bob$ lncli --network=simnet channelbalance
 ```
 
 Now we have open channel in which we sent only one payment, let's imagine
@@ -218,7 +219,7 @@ it!
 ```bash
 # List the "Alice" channel and retrieve "channel_point" which represents
 # the opened channel:
-alice$ lncli listchannels
+alice$ lncli --network=simnet listchannels
 {
     "channels": [
         {
@@ -245,17 +246,17 @@ alice$ lncli listchannels
 
 # Channel point consists of two numbers separated by a colon. The first one 
 # is "funding_txid" and the second one is "output_index":
-alice$ lncli closechannel --funding_txid=<funding_txid> --output_index=<output_index>
+alice$ lncli --network=simnet closechannel --funding_txid=<funding_txid> --output_index=<output_index>
 
 # Include close transaction in a block thereby closing the channel:
 $ docker-compose run btcctl generate 3
 
 # Check "Alice" on-chain balance was credited by her settled amount in the channel:
-alice$ lncli walletbalance
+alice$ lncli --network=simnet walletbalance
 
 # Check "Bob" on-chain balance was credited with the funds he received in the
 # channel:
-bob$ lncli walletbalance
+bob$ lncli --network=simnet walletbalance
 {
     "total_balance": "10000",
     "confirmed_balance": "10000",
@@ -315,7 +316,7 @@ The `Faucet` node address can be found at the [Faucet Lightning Community webpag
 $ docker-compose up -d "alice"; docker exec -i -t "alice" bash
 
 # Connect "Alice" to the "Faucet" node:
-alice$ lncli connect <faucet_identity_address>@<faucet_host>
+alice$ lncli --network=simnet connect <faucet_identity_address>@<faucet_host>
 ```
 
 After a connection is achieved, the `Faucet` node should create the channel

--- a/guides/javascript-grpc.md
+++ b/guides/javascript-grpc.md
@@ -93,14 +93,15 @@ call.on('data', function(invoice) {
 ```
 
 Now, create an invoice for your node at `localhost:10009`and send a payment to
-it from another node.
+it from another node. If `lnd` is running on a network other than mainnet, the
+network must be specified.
 ```bash
-$ lncli addinvoice --amt=100
+$ lncli --network=NETWORK addinvoice --amt=100
 {
 	"r_hash": <RHASH>,
 	"pay_req": <PAYMENT_REQUEST>
 }
-$ lncli sendpayment --pay_req=<PAYMENT_REQUEST>
+$ lncli --network=NETWORK sendpayment --pay_req=<PAYMENT_REQUEST>
 ```
 Your Javascript console should now display the details of the recently satisfied
 invoice.

--- a/guides/python-grpc.md
+++ b/guides/python-grpc.md
@@ -93,14 +93,15 @@ for invoice in stub.SubscribeInvoices(request):
 ```
 
 Now, create an invoice for your node at `localhost:10009`and send a payment to
-it from another node.
+it from another node. If `lnd` is running on a network other than mainnet, the
+network must be specified.
 ```bash
-$ lncli addinvoice --amt=100
+$ lncli --network=NETWORK addinvoice --amt=100
 {
 	"r_hash": <R_HASH>,
 	"pay_req": <PAY_REQ>
 }
-$ lncli sendpayment --pay_req=<PAY_REQ>
+$ lncli --network=NETWORK sendpayment --pay_req=<PAY_REQ>
 ```
 
 Your Python console should now display the details of the recently satisfied

--- a/guides/python-grpc.md
+++ b/guides/python-grpc.md
@@ -145,9 +145,10 @@ To authenticate using macaroons you need to include the macaroon in the metadata
 ```python
 import codecs
 
-# Lnd admin macaroon is at ~/.lnd/admin.macaroon on Linux and
-# ~/Library/Application Support/Lnd/admin.macaroon on Mac
-with open(os.path.expanduser('~/.lnd/admin.macaroon'), 'rb') as f:
+# Lnd data/chain/bitcoin/NETWORK/admin.macaroon is at ~/.lnd/admin.macaroon on Linux and
+# ~/Library/Application Support/Lnd/data/chain/bitcoin/NETWORK/admin.macaroon on Mac
+# where NETWORK needs to be replaced with the network corresponding to the desired macaroon.
+with open(os.path.expanduser('~/.lnd/data/chain/bitcoin/NETWORK/admin.macaroon'), 'rb') as f:
     macaroon_bytes = f.read()
     macaroon = codecs.encode(macaroon_bytes, 'hex')
 ```

--- a/tutorial/01-lncli.md
+++ b/tutorial/01-lncli.md
@@ -256,7 +256,7 @@ Open up a new terminal window, set `$GOPATH` and include `$GOPATH/bin` in your
 `PATH` as usual. Let's create Alice's wallet and set her passphrase:
 ```bash
 cd $GOPATH/dev/alice
-alice$ lncli --network=simnet --rpcserver=localhost:10001 --macaroonpath=data/admin.macaroon create
+alice$ lncli --network=simnet --rpcserver=localhost:10001 --macaroonpath=data/chain/bitcoin/simnet/admin.macaroon create
 ```
 You'll be asked to input and confirm a wallet password for Alice, which must be
 longer than 8 characters. You also have the option to add a passphrase to your
@@ -266,7 +266,7 @@ passphrase.
 
 You can now request some basic information as follows:
 ```bash
-alice$ lncli --network=simnet --rpcserver=localhost:10001 --macaroonpath=data/admin.macaroon getinfo
+alice$ lncli --network=simnet --rpcserver=localhost:10001 --macaroonpath=data/chain/bitcoin/simnet/admin.macaroon getinfo
 ```
 `lncli` just made an RPC call to the Alice `lnd` node. This is a good way to
 test if your nodes are up and running and `lncli` is functioning properly. Note
@@ -279,21 +279,21 @@ respectively.
 ```bash
 # In a new terminal window, setting $GOPATH, etc.
 cd $GOPATH/dev/bob
-bob$ lncli --network=simnet --rpcserver=localhost:10002 --macaroonpath=data/admin.macaroon create
+bob$ lncli --network=simnet --rpcserver=localhost:10002 --macaroonpath=data/chain/bitcoin/simnet/admin.macaroon create
 # Note that you'll have to enter an 8+ character password and "n" for the mnemonic.
 
 # In a new terminal window:
 cd $GOPATH/dev/charlie
-charlie$ lncli --network=simnet --rpcserver=localhost:10003 --macaroonpath=data/admin.macaroon create
+charlie$ lncli --network=simnet --rpcserver=localhost:10003 --macaroonpath=data/chain/bitcoin/simnet/admin.macaroon create
 # Note that you'll have to enter an 8+ character password and "n" for the mnemonic.
 ```
 
 To avoid typing the `--rpcserver=localhost:1000X` and `--macaroonpath` flag
 every time, we can set some aliases. Add the following to your `.bashrc`:
 ```bash
-alias lncli-alice="lncli --network=simnet --rpcserver=localhost:10001 --macaroonpath=data/admin.macaroon"
-alias lncli-bob="lncli --network=simnet --rpcserver=localhost:10002 --macaroonpath=data/admin.macaroon"
-alias lncli-charlie="lncli --network=simnet --rpcserver=localhost:10003 --macaroonpath=data/admin.macaroon"
+alias lncli-alice="lncli --network=simnet --rpcserver=localhost:10001 --macaroonpath=data/chain/bitcoin/simnet/admin.macaroon"
+alias lncli-bob="lncli --network=simnet --rpcserver=localhost:10002 --macaroonpath=data/chain/bitcoin/simnet/admin.macaroon"
+alias lncli-charlie="lncli --network=simnet --rpcserver=localhost:10003 --macaroonpath=data/chain/bitcoin/simnet/admin.macaroon"
 ```
 
 To make sure this was applied to all of your current terminal windows, rerun

--- a/tutorial/01-lncli.md
+++ b/tutorial/01-lncli.md
@@ -239,6 +239,9 @@ location of our application data, we have to set `--macaroonpath` in the
 following command. To disable macaroons, pass the `--no-macaroons` flag into
 both `lncli` and `lnd`.
 
+For usage of networks other than mainnet, an additional `--network` flag must
+be passed into `lncli` specifying the network, in this case simnet.
+
 `lnd` allows you to encrypt your wallet with a passphrase and optionally encrypt
 your cipher seed passphrase as well. This can be turned off by passing
 `--noencryptwallet` into `lnd` or `lnd.conf`. We recommend going through this
@@ -253,7 +256,7 @@ Open up a new terminal window, set `$GOPATH` and include `$GOPATH/bin` in your
 `PATH` as usual. Let's create Alice's wallet and set her passphrase:
 ```bash
 cd $GOPATH/dev/alice
-alice$ lncli --rpcserver=localhost:10001 --macaroonpath=data/admin.macaroon create
+alice$ lncli --network=simnet --rpcserver=localhost:10001 --macaroonpath=data/admin.macaroon create
 ```
 You'll be asked to input and confirm a wallet password for Alice, which must be
 longer than 8 characters. You also have the option to add a passphrase to your
@@ -263,7 +266,7 @@ passphrase.
 
 You can now request some basic information as follows:
 ```bash
-alice$ lncli --rpcserver=localhost:10001 --macaroonpath=data/admin.macaroon getinfo
+alice$ lncli --network=simnet --rpcserver=localhost:10001 --macaroonpath=data/admin.macaroon getinfo
 ```
 `lncli` just made an RPC call to the Alice `lnd` node. This is a good way to
 test if your nodes are up and running and `lncli` is functioning properly. Note
@@ -276,21 +279,21 @@ respectively.
 ```bash
 # In a new terminal window, setting $GOPATH, etc.
 cd $GOPATH/dev/bob
-bob$ lncli --rpcserver=localhost:10002 --macaroonpath=data/admin.macaroon create
+bob$ lncli --network=simnet --rpcserver=localhost:10002 --macaroonpath=data/admin.macaroon create
 # Note that you'll have to enter an 8+ character password and "n" for the mnemonic.
 
 # In a new terminal window:
 cd $GOPATH/dev/charlie
-charlie$ lncli --rpcserver=localhost:10003 --macaroonpath=data/admin.macaroon create
+charlie$ lncli --network=simnet --rpcserver=localhost:10003 --macaroonpath=data/admin.macaroon create
 # Note that you'll have to enter an 8+ character password and "n" for the mnemonic.
 ```
 
 To avoid typing the `--rpcserver=localhost:1000X` and `--macaroonpath` flag
 every time, we can set some aliases. Add the following to your `.bashrc`:
 ```bash
-alias lncli-alice="lncli --rpcserver=localhost:10001 --macaroonpath=data/admin.macaroon"
-alias lncli-bob="lncli --rpcserver=localhost:10002 --macaroonpath=data/admin.macaroon"
-alias lncli-charlie="lncli --rpcserver=localhost:10003 --macaroonpath=data/admin.macaroon"
+alias lncli-alice="lncli --network=simnet --rpcserver=localhost:10001 --macaroonpath=data/admin.macaroon"
+alias lncli-bob="lncli --network=simnet --rpcserver=localhost:10002 --macaroonpath=data/admin.macaroon"
+alias lncli-charlie="lncli --network=simnet --rpcserver=localhost:10003 --macaroonpath=data/admin.macaroon"
 ```
 
 To make sure this was applied to all of your current terminal windows, rerun


### PR DESCRIPTION
- `lncli` now requires a `--network` flag when connecting to a non-mainnet lnd node. 

- the path to macaroons has changed

Replaces #51.




