### PR TITLE
Update lnd argument

### DIFF
--- a/tutorial/01-lncli.md
+++ b/tutorial/01-lncli.md
@@ -406,7 +406,7 @@ alice$ lncli-alice connect <BOB_PUBKEY>@localhost:10012
 
 }
 ```
-Notice that `localhost:10012` corresponds to the `--peerport=10012` flag we set
+Notice that `localhost:10012` corresponds to the `--listen=10012` flag we set
 when starting the Bob `lnd` node.
 
 Let's check that Alice and Bob are now aware of each other.


### PR DESCRIPTION
“peerport” does not seem to be, or no longer is, an argument you could pass to lnd. To avoid confusion and stay consistent just continue using “listen.”