### PR TITLE
Remove Lightning Conductor

### DIFF
--- a/_pages/lapps.md
+++ b/_pages/lapps.md
@@ -120,9 +120,6 @@ Eclair is a Scala implementation of the Lightning Network built by [ACINQ](https
 * [Starblocks](https://starblocks.acinq.co/#/): Virtual coffee shop
 * [Strike](https://strike.acinq.co/#/): Stripe-like Lightning payment aggregator
   API (custodial)
-* [Lightning Conductor](http://lightningconductor.net/): A service for
-  converting Lightning balances to BTC and back without having to close
-  or open channels, currently on testnet.
 
 ### c-Lightning Lapps
 


### PR DESCRIPTION
Received emails that the Lightning Conductor service is no longer operational. Apparently there are "dozens of complaints across different social media sites," we were asked to "please remove so others don't lose their coins."